### PR TITLE
Add belongs_to :polimorphic key option only when used

### DIFF
--- a/lib/awesome_nested_set/awesome_nested_set.rb
+++ b/lib/awesome_nested_set/awesome_nested_set.rb
@@ -98,9 +98,9 @@ module CollectiveIdea #:nodoc:
           :primary_key => primary_column_name,
           :counter_cache => acts_as_nested_set_options[:counter_cache],
           :inverse_of => (:children unless acts_as_nested_set_options[:polymorphic]),
-          :polymorphic => acts_as_nested_set_options[:polymorphic],
           :touch => acts_as_nested_set_options[:touch]
         }
+        options[:polymorphic] = true if acts_as_nested_set_options[:polymorphic]
         options[:optional] = true if ActiveRecord::VERSION::MAJOR >= 5
         belongs_to :parent, options
       end


### PR DESCRIPTION
Since osmaelo/rails@2c008d9, belongs_to accept :polymorphic as a
valid option only when set to true.

We can switch back to the the actual gem once it's updated to support Rails 6.1